### PR TITLE
Use native sorting, filtering and paging, allow get query

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,13 @@
 {
   "extends": [
-    "standard",
-    "standard-react",
-    "prettier",
-    "prettier/react"
+//    "standard",
+//    "standard-react"
+//    "prettier",
+//    "prettier/react"
   ],
   "plugins": [
-    "prettier",
-    "react"
+//    "prettier",
+//    "react"
   ],
   "parser": "babel-eslint",
   "rules": {
@@ -16,20 +16,20 @@
     "react/jsx-filename-extension": "off",
     "react/no-array-index-key": "off",
     "no-console": "off",
-    "camelcase": "off",
-    "prettier/prettier": [
-      "error",
-      {
-        "printWidth": 120,
-        "tabWidth": 2,
-        "singleQuote": true,
-        "trailingComma": "none",
-        "bracketSpacing": true,
-        "jsxBracketSameLine": false,
-        "parser": "flow",
-        "semi": true
-      }
-    ]
+    "camelcase": "off"
+//    "prettier/prettier": [
+//      "error",
+//      {
+//        "printWidth": 120,
+//        "tabWidth": 2,
+//        "singleQuote": true,
+//        "trailingComma": "none",
+//        "bracketSpacing": true,
+//        "jsxBracketSameLine": false,
+//        "parser": "flow",
+//        "semi": true
+//      }
+//    ]
   },
   "parserOptions": {
     "ecmaVersion": 2016,

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "prop-types": "^15.7.2",
     "ra-realtime": "^2.8.6",
     "react": "16.9.0",
-    "react-dom": "^16.9.0"
+    "react-dom": "^16.9.0",
+    "react-router-redux": "~5.0.0-alpha.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "prop-types": "^15.7.2",
     "react": "16.9.0",
     "react-admin": "^2.9.6",
-    "react-dom": "^16.9.0"
+    "react-dom": "^16.9.0",
+    "ra-realtime": "^2.8.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "firebase": "^6.6.1",
     "prop-types": "^15.7.2",
     "react": "16.9.0",
-    "react-admin": "^2.9.6",
+    "react-admin": "^2.9.8",
     "react-dom": "^16.9.0",
     "ra-realtime": "^2.8.6"
   }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "prop-types": "^15.7.2",
     "ra-realtime": "^2.8.6",
     "react": "16.9.0",
-    "react-admin": "^2.9.8",
     "react-dom": "^16.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "prop-types": "^15.7.2",
     "react": "16.9.0",
     "react-admin": "^2.9.6",
-    "react-dom": "^16.9.0",
-    "sort-by": "^1.2.0"
+    "react-dom": "^16.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,10 +92,11 @@
   },
   "dependencies": {
     "firebase": "^6.6.1",
+    "flat": "^5.0.0",
     "prop-types": "^15.7.2",
+    "ra-realtime": "^2.8.6",
     "react": "16.9.0",
     "react-admin": "^2.9.8",
-    "react-dom": "^16.9.0",
-    "ra-realtime": "^2.8.6"
+    "react-dom": "^16.9.0"
   }
 }

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -39,8 +39,8 @@ const dataProvider = base64Uploader(RestProvider(firebaseConfig, { trackedResour
 const realtimeSaga = createRealtimeSaga(dataProvider);
 
 const App = () => (
-  <Admin dataProvider={dataProvider} customSagas={[realtimeSaga]}>
-    <Resource name="posts" list={PostList} edit={PostEdit} create={PostCreate} />
+  <Admin dataProvider={dataProvider} customSagas={[]}>
+    <Resource name=".posts" list={PostList} edit={PostEdit} create={PostCreate} />
     <Resource name="users" list={UserList} edit={UserEdit} create={UserCreate} />
   </Admin>
 );

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { Admin, Resource } from 'react-admin';
-import { RestProvider, AuthProvider, base64Uploader } from '../lib';
+// import { RestProvider, AuthProvider, base64Uploader } from '../lib';
+import { RestProvider, base64Uploader, createRealtimeSaga } from '../lib';
 
 import { PostList, PostEdit, PostCreate } from './Posts';
 import { UserList, UserEdit, UserCreate } from './Users';
 
-const firebaseConfig = {
+let firebaseConfig = {
   apiKey: 'AIzaSyASpb1daoPZdpzY_-d1mkzgO-sxoBw6i9o',
   authDomain: 'react-admin-firestore-client.firebaseapp.com',
   databaseURL: 'https://react-admin-firestore-client.firebaseio.com',
@@ -14,18 +15,31 @@ const firebaseConfig = {
   messagingSenderId: '796768771332'
 };
 
+firebaseConfig = {
+  apiKey: 'AIzaSyBPTNjD4I30GyYSpD4ixjY2ZQC7pGCyFEA',
+  authDomain: 'mlbot-257017.firebaseapp.com',
+  databaseURL: 'https://mlbot-257017.firebaseio.com',
+  projectId: 'mlbot-257017',
+  storageBucket: 'mlbot-257017.appspot.com',
+  messagingSenderId: '995641416070',
+  appId: '1:995641416070:web:aec2eea9eebd6b98b93407',
+  measurementId: 'G-G324D9KTNP'
+};
+
 const trackedResources = [{ name: 'posts' }, { name: 'users' }];
 
-const authConfig = {
-  userProfilePath: '/users/',
-  userAdminProp: 'isAdmin'
-};
+// const authConfig = {
+//   userProfilePath: '/users/',
+//   userAdminProp: 'isAdmin'
+// };
 
 // to run this demo locally, please feel free to disable authProvider to bypass login page
 
 const dataProvider = base64Uploader(RestProvider(firebaseConfig, { trackedResources }));
+const realtimeSaga = createRealtimeSaga(dataProvider);
+
 const App = () => (
-  <Admin dataProvider={dataProvider} authProvider={AuthProvider(authConfig)}>
+  <Admin dataProvider={dataProvider} customSagas={[realtimeSaga]}>
     <Resource name="posts" list={PostList} edit={PostEdit} create={PostCreate} />
     <Resource name="users" list={UserList} edit={UserEdit} create={UserCreate} />
   </Admin>

--- a/src/demo/Posts.js
+++ b/src/demo/Posts.js
@@ -14,11 +14,20 @@ import {
   SimpleForm,
   TextInput,
   ImageInput,
-  ImageField
+  ImageField,
+    Filter
 } from 'react-admin';
 
+import Pagination from '../lib/Pagination';
+
+const PostListFilter = props => (
+    <Filter {...props}>
+      <TextInput label="test" source=" .price>"/>
+    </Filter>
+);
+
 export const PostList = props => (
-  <List {...props}>
+  <List {...props} pagination={<Pagination/>} filters={<PostListFilter/>}>
     <Datagrid>
       <TextField source="id" />
       <ReferenceField label="User" source="userId" reference="users" allowEmpty>
@@ -58,3 +67,25 @@ export const PostCreate = props => (
     </SimpleForm>
   </Create>
 );
+
+/*
+MACRO:
+PIB
+TX JUROS
+CONSUMO
+DEFICIT PUBLICO
+CAMBIO
+EMPREGO
+INFLACAO
+
+SETORIAL:
+
+BALANCA DE PAGAMENTOS
+PAUTA DE IN/OUT
+
+CONTABILIDADE SA'S
+
+EXTRATIVISTA
+MINERAL
+PAPEL-CELULOSE
+*/

--- a/src/demo/Users.js
+++ b/src/demo/Users.js
@@ -12,8 +12,10 @@ import {
   ImageField
 } from 'react-admin';
 
+import Pagination from '../lib/Pagination';
+
 export const UserList = props => (
-  <List title="All users" {...props}>
+  <List title="All users" {...props} pagination={<Pagination />}>
     <Datagrid>
       <TextField source="id" />
       <TextField source="name" />

--- a/src/lib/CollectionGroupButtons.js
+++ b/src/lib/CollectionGroupButtons.js
@@ -1,0 +1,9 @@
+import React from "react";
+import {
+    ShowButton,
+    CloneButton,
+    EditButton,
+    DeleteButton,
+    DeleteWithUndoButton,
+    DeleteWithConfirmButton
+} from 'react-admin';

--- a/src/lib/Pagination.js
+++ b/src/lib/Pagination.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import Toolbar from '@material-ui/core/Toolbar';
+
+export default ({ page, perPage, total, setPage, ...props }) => {
+    // console.log(props);
+    return (
+        <Toolbar>
+            {page > 1 &&
+            <Button color="primary" key="prev" icon={<ChevronLeft />} onClick={() => setPage(page - 1)}>
+                Prev
+            </Button>
+            }
+            {total > (perPage * page) &&
+            <Button color="primary" key="next" icon={<ChevronRight />} onClick={() => setPage(page + 1)} labelposition="before">
+                Next
+            </Button>
+            }
+        </Toolbar>
+    );
+};

--- a/src/lib/createRealtimeSaga.js
+++ b/src/lib/createRealtimeSaga.js
@@ -1,23 +1,31 @@
 import realtimeSaga from 'ra-realtime';
 import Methods from './methods.js';
 
-const observeRequest = dataProvider => (type, resource, params) => {
+const observeRequest = (dataProvider, onDataUpdated = () => {}) => (type, resource, params) => {
   return {
     subscribe(observer) {
       const snapshotParams = Object.assign({}, params);
 
       snapshotParams[Methods.snapshotFlag] = true;
 
+      let isFirst = true;
+
       const cancelSnapshotsPromise = dataProvider(type, resource, snapshotParams).then(query => {
         return query.onSnapshot(
           snapshot => {
+
+            if (!isFirst) {
+              isFirst = false;
+            }
+
+            onDataUpdated(type, resource);
+
             // New data received, notify the observer
             if (snapshot.docs) {
               const docs = snapshot.docs.slice(params.pagination.perPage * (params.pagination.page - 1));
 
               observer.next({
                 data: docs.map(doc => doc.data()),
-                keys: docs.map(doc => doc.id),
                 total: docs.length
               });
             } else {

--- a/src/lib/createRealtimeSaga.js
+++ b/src/lib/createRealtimeSaga.js
@@ -54,4 +54,4 @@ const observeRequest = (dataProvider, onDataUpdated = () => {}) => (type, resour
   };
 };
 
-export default dataProvider => realtimeSaga(observeRequest(dataProvider));
+export default (dataProvider, onDataUpdated) => realtimeSaga(observeRequest(dataProvider, onDataUpdated));

--- a/src/lib/createRealtimeSaga.js
+++ b/src/lib/createRealtimeSaga.js
@@ -1,11 +1,12 @@
 import realtimeSaga from 'ra-realtime';
+import { SnapshotFlag } from './methods.js';
 
 const observeRequest = dataProvider => (type, resource, params) => {
    
     return {
         subscribe(observer) {
         
-            params.snapshot = true;
+            params[SnapshotFlag] = true;
           
             const query = dataProvider(type, resource, params);
             const cancelSnapshots = query.onSnapshot(

--- a/src/lib/createRealtimeSaga.js
+++ b/src/lib/createRealtimeSaga.js
@@ -1,0 +1,27 @@
+import realtimeSaga from 'ra-realtime';
+
+const observeRequest = dataProvider => (type, resource, params) => {
+   
+    return {
+        subscribe(observer) {
+        
+            const query = dataProvider(type, resource, params);
+            const cancelSnapshots = query.onSnapshot(snaphot => {
+              observer.next(snapshot.docs)// New data received, notify the observer
+            })
+
+            const subscription = {
+                unsubscribe() {
+                    // Clean up after ourselves
+                    cancelSnapshots();
+                    // Notify the saga that we cleaned up everything
+                    observer.complete();
+                }
+            };
+
+            return subscription;
+        },
+    };
+};
+
+export default dataProvider => realtimeSaga(observeRequest(dataProvider));

--- a/src/lib/createRealtimeSaga.js
+++ b/src/lib/createRealtimeSaga.js
@@ -5,6 +5,8 @@ const observeRequest = dataProvider => (type, resource, params) => {
     return {
         subscribe(observer) {
         
+            params.snapshot = true;
+          
             const query = dataProvider(type, resource, params);
             const cancelSnapshots = query.onSnapshot(snaphot => {
               observer.next(snapshot.docs)// New data received, notify the observer

--- a/src/lib/createRealtimeSaga.js
+++ b/src/lib/createRealtimeSaga.js
@@ -8,9 +8,14 @@ const observeRequest = dataProvider => (type, resource, params) => {
             params.snapshot = true;
           
             const query = dataProvider(type, resource, params);
-            const cancelSnapshots = query.onSnapshot(snaphot => {
-              observer.next(snapshot.docs)// New data received, notify the observer
-            })
+            const cancelSnapshots = query.onSnapshot(
+              snaphot => {
+                observer.next(snapshot.docs)// New data received, notify the observer
+              },
+              error => {
+                observer.error(error)); // Ouch, an error occured, notify the observer
+              }
+            )
 
             const subscription = {
                 unsubscribe() {

--- a/src/lib/createRealtimeSaga.js
+++ b/src/lib/createRealtimeSaga.js
@@ -1,7 +1,7 @@
 import realtimeSaga from 'ra-realtime';
 import Methods from './methods.js';
 
-const observeRequest = (dataProvider, onDataUpdated = () => {}) => (type, resource, params) => {
+const observeRequest = (dataProvider, onDataUpdated) => (type, resource, params) => {
   return {
     subscribe(observer) {
       const snapshotParams = Object.assign({}, params);
@@ -18,7 +18,7 @@ const observeRequest = (dataProvider, onDataUpdated = () => {}) => (type, resour
               isFirst = false;
             }
 
-            onDataUpdated(type, resource);
+            if (onDataUpdated) onDataUpdated(type, resource);
 
             // New data received, notify the observer
             if (snapshot.docs) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -2,7 +2,7 @@ import RestProvider from './RestProvider';
 import AuthProvider from './AuthProvider';
 import * as RAFirebaseMethods from './methods';
 import base64Uploader from './Base64Uploader';
-import Pagination from './Pagination';
+// import Pagination from './Pagination';
 import createRealtimeSaga from './createRealtimeSaga';
 
-export { RestProvider, AuthProvider, RAFirebaseMethods, base64Uploader, createRealtimeSaga, Pagination };
+export { RestProvider, AuthProvider, RAFirebaseMethods, base64Uploader, createRealtimeSaga };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -2,5 +2,6 @@ import RestProvider from './RestProvider';
 import AuthProvider from './AuthProvider';
 import * as RAFirebaseMethods from './methods';
 import base64Uploader from './Base64Uploader';
+import createRealtimeSaga from './createRealtimeSaga';
 
-export { RestProvider, AuthProvider, RAFirebaseMethods, base64Uploader };
+export { RestProvider, AuthProvider, RAFirebaseMethods, base64Uploader, createRealtimeSaga };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -2,6 +2,7 @@ import RestProvider from './RestProvider';
 import AuthProvider from './AuthProvider';
 import * as RAFirebaseMethods from './methods';
 import base64Uploader from './Base64Uploader';
+import Pagination from './Pagination';
 import createRealtimeSaga from './createRealtimeSaga';
 
-export { RestProvider, AuthProvider, RAFirebaseMethods, base64Uploader, createRealtimeSaga };
+export { RestProvider, AuthProvider, RAFirebaseMethods, base64Uploader, createRealtimeSaga, Pagination };

--- a/src/lib/methods.js
+++ b/src/lib/methods.js
@@ -303,15 +303,11 @@ const getList = async (params, resourceName, resourceData) => {
 const getMany = async (params, resourceName, resourceData) => {
   let data = [];
 
-  const firestore = firebase.firestore();
+  const collection = firebase.firestore().collection(resourceName);
 
-  const snapshot = await firestore.getAll(
-    ...params.ids.map(id => {
-      firestore.collection(resourceName).doc(id);
-    })
-  );
+  const snapshots = await Promise.all(params.ids.map(id => collection.doc(id).get()));
 
-  snapshot.forEach(docRef => {
+  snapshots.forEach(docRef => {
     data.push(docRef.data());
   });
 

--- a/src/lib/methods.js
+++ b/src/lib/methods.js
@@ -3,6 +3,10 @@ import 'firebase/firestore';
 import 'firebase/storage';
 import { CREATE } from 'react-admin';
 
+const SnapshotFlag = Symbol('snapshot');
+
+export SnapshotFlag;
+
 const convertFileToBase64 = file =>
   new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -172,7 +176,7 @@ const getOne = async (params, resourceName, resourceData) => {
       .collection(resourceName)
       .doc(params.id);
     
-    if (params.snaphost) return query;
+    if (params[SnapshotFlag]) return query;
     
     const result = await query.get();
 
@@ -212,7 +216,7 @@ const getList = async (params, resourceName, resourceData) => {
     
     Object.keys(params.filter).forEach(field => {query.where(field, '==', params.filter[field])})
     
-    if (params.snaphost) return query;
+    if (params[SnapshotFlag]) return query;
     
     let snapshots = await query.get()
 
@@ -238,6 +242,8 @@ const getMany = async (params, resourceName, resourceData) => {
   const firestore = firabase.firestore()
   
   const snapshot = await firestore.getAll(...params.ids.map(id => {firestore.collection(resourceName).doc(id)}))
+  
+  if (params[SnapshotFlag]) return snapshot;
   
   snapshot.forEach(docRef => {data.push(docRef.data())})
   

--- a/src/lib/methods.js
+++ b/src/lib/methods.js
@@ -234,11 +234,13 @@ const getList = async (params, resourceName, resourceData) => {
 
 const getMany = async (params, resourceName, resourceData) => {
   let data = [];
-  /* eslint-disable no-await-in-loop */
-  for (const id of params.ids) {
-    let { data: item } = await getOne({ id }, resourceName, resourceData);
-    data.push(item);
-  }
+  
+  const firestore = firabase.firestore()
+  
+  const snapshot = await firestore.getAll(...params.ids.map(id => {firestore.collection(resourceName).doc(id)}))
+  
+  snapshot.forEach(docRef => {data.push(docRef.data())})
+  
   return { data };
 };
 

--- a/src/lib/methods.js
+++ b/src/lib/methods.js
@@ -308,7 +308,12 @@ const getMany = async (params, resourceName, resourceData) => {
   const snapshots = await Promise.all(params.ids.map(id => collection.doc(id).get()));
 
   snapshots.forEach(docRef => {
-    data.push(docRef.data());
+
+    const doc = docRef.data();
+
+    doc.id = doc.id || docRef.id;
+
+    data.push(doc);
   });
 
   return { data };


### PR DESCRIPTION
Use firestore's native sorting - orderBy(field, order) - filtering - where(field, op, value) - and paging - limit(limit) and offset(offset).

Allow returning query for use with ra-realtime saga when params.snapshot is true (or should params.snapshot be the callback for query.onSnapshot(callback) ?)

Didn't tested yet, will do soon.